### PR TITLE
Fixing Markdown Formatting in ReadMe.md for links and style

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This module provides a Ruby interface for data serialization in YAML format.
 
-The \YAML module is an alias for
+The `YAML` module is an alias for
 [Psych](https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html),
-the \YAML engine for Ruby.
+the `YAML` engine for Ruby.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This module provides a Ruby interface for data serialization in YAML format.
 
 The \YAML module is an alias for
-{Psych}[https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html],
+[Psych](https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html),
 the \YAML engine for Ruby.
 
 ## Installation
@@ -38,7 +38,7 @@ YAML.dump("foo")     # => "--- foo\n...\n"
 ```
 
 For detailed documentation, see
-{Psych}[https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html].
+[Psych](https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html).
 
 ## Security
 


### PR DESCRIPTION
- Change Markdown formatting for links to https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html to use `[]()` Markdown style
- Change \YAML to `YAML` with Markdown format