### PR TITLE
Fix Psych documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ YAML.dump("foo")     # => "--- foo\n...\n"
 ```
 
 For detailed documentation, see
-[Psych](https://ruby-doc.org/stdlib/libdoc/psych/rdoc/index.html).
+[Psych](https://ruby-doc.org/stdlib/exts/psych/Psych.html).
 
 ## Security
 


### PR DESCRIPTION
The link to the Psych documentation 404s. This fixes the link to the current Psych docs.