### PR TITLE
Make PStore support as optional

### DIFF
--- a/lib/yaml/store.rb
+++ b/lib/yaml/store.rb
@@ -3,7 +3,11 @@
 # YAML::Store
 #
 require 'yaml'
-require 'pstore'
+
+begin
+  require 'pstore'
+rescue LoadError
+end
 
 # YAML::Store provides the same functionality as PStore, except it uses YAML
 # to dump objects instead of Marshal.
@@ -83,4 +87,4 @@ class YAML::Store < PStore
   def empty_marshal_checksum
     CHECKSUM_ALGO.digest(empty_marshal_data)
   end
-end
+end if defined?(::PStore)

--- a/test/yaml/test_store.rb
+++ b/test/yaml/test_store.rb
@@ -177,4 +177,4 @@ class YAMLStoreTest < Test::Unit::TestCase
     end
     assert_equal(indentation_3_yaml, File.read(@yaml_store_file), bug12800)
   end
-end
+end if defined?(::YAML::Store)


### PR DESCRIPTION
I have a plan to make `PStore` to bundled gems. This means Ruby 3.5 will not have `pstore` library with some environment or platform.

We should make `YAML::PStore` as optional.