### PR TITLE
FIx "pstore was loaded from the standard lib"-warning.

### DIFF
--- a/yaml.gemspec
+++ b/yaml.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "pstore", "~> 0.1"
 end


### PR DESCRIPTION
Hey :wave:,

this should fix the warning:

`pstore was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.`

in ruby `3.3.5`.

thanks